### PR TITLE
Instantiate magic.Magic by calling the class in the documentation

### DIFF
--- a/docs/source/guide_content
+++ b/docs/source/guide_content
@@ -58,7 +58,7 @@ To ensure that resources are correctly released by :class:`magic.Magic`, it's
 necessary to either explicitly call :meth:`~magic.Magic.close` on instances,
 or use ``with`` statement. ::
 
-    >>> with magic.Magic as m:
+    >>> with magic.Magic() as m:
     ...     pass
     ...
 
@@ -69,7 +69,7 @@ exceptions.
 To identify a file from it's filename, use the
 :meth:`~magic.Magic.id_filename()` method. ::
 
-    >>> with magic.Magic as m:
+    >>> with magic.Magic() as m:
     ...     m.id_filename('setup.py')
     ...
     'Python script, ASCII text executable'
@@ -77,7 +77,7 @@ To identify a file from it's filename, use the
 Similarily to identify a file from a string that has already been read, use the
 :meth:`~magic.Magic.id_buffer` method. ::
 
-    >>> with magic.Magic as m:
+    >>> with magic.Magic() as m:
     ...     m.id_buffer('#!/usr/bin/python\n')
     ...
     'Python script, ASCII text executable'


### PR DESCRIPTION
Using brackets to call magic.Magic seems to fix the problem reported in issue #10.
