### PR TITLE
Don't raise unicode error on malformed JPEG meta

### DIFF
--- a/magic/compatability.py
+++ b/magic/compatability.py
@@ -53,5 +53,5 @@ def str_return(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         value = func(*args, **kwargs)
-        return value.decode()
+        return value.decode(errors='replace')
     return wrapper


### PR DESCRIPTION
I encountered a JPEG file that had invalid unicode string inside "software" meta tag. This caused UnicodeDecodeError in filemagic's compatibility.py:

```
    description = magic.id_buffer(chunk)
  File "/Users/amw/.virtualenvs/asd/lib/python3.6/site-packages/magic/identify.py", line 29, in wrapper
    return func(self, *args, **kwargs)
  File "/Users/amw/.virtualenvs/asd/lib/python3.6/site-packages/magic/compatability.py", line 30, in wrapper
    return func(*encoder(args), **kwargs)
  File "/Users/amw/.virtualenvs/asd/lib/python3.6/site-packages/magic/compatability.py", line 56, in wrapper
    return value.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc7 in position 210: invalid continuation byte
```

In this PR I am passing `errors='replace'` option to the `decode` method so that we can return safe string with the rest of the file description intact. Another alternative is `ignore` which I deemed less safe.

When testing my specific file I have noticed that both `replace` and `ignore` returned strings are unicode equivalent when copied to some context (like this GitHub page), but they do look different in Terminal. See below comparison text and screenshots.

# python `replace`
```
JPEG image data, JFIF standard 1.01, resolution (DPI), density 96x96, segment length 16, Exif Standard: [TIFF image data, little-endian, direntries=4, xresolution=62, yresolution=70, resolutionunit=2, software=ˮӡרҵ], baseline, precision 8, 560x372, frames 3
```
<img width="536" alt="replace" src="https://cloud.githubusercontent.com/assets/29783/24025460/bdcc5236-0a77-11e7-9945-e1893c83b9b4.png">

# python `ignore`
```
JPEG image data, JFIF standard 1.01, resolution (DPI), density 96x96, segment length 16, Exif Standard: [TIFF image data, little-endian, direntries=4, xresolution=62, yresolution=70, resolutionunit=2, software=ˮӡרҵ], baseline, precision 8, 560x372, frames 3
```
<img width="536" alt="ignore" src="https://cloud.githubusercontent.com/assets/29783/24025469/cb7d231a-0a77-11e7-8cfe-ca90584dc2d5.png">

# `file` shell command
```
JPEG image data, JFIF standard 1.01, resolution (DPI), density 96x96, segment length 16, Exif Standard: [TIFF image data, little-endian, direntries=4, xresolution=62, yresolution=70, resolutionunit=2, software=????ˮӡרҵ??], baseline, precision 8, 560x372, frames 3
```
<img width="534" alt="file-cmd" src="https://cloud.githubusercontent.com/assets/29783/24025481/df8549d2-0a77-11e7-946e-0609c7ae01f3.png">